### PR TITLE
Export `package.json`

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -5,6 +5,7 @@
   "main": "./ssr-window.esm.js",
   "module": "./ssr-window.esm.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": "./ssr-window.esm.js"
   },
   "typings": "types/ssr-window.d.ts",


### PR DESCRIPTION
Some build tools try to read the `package.json` and it creates issues if it's not exported