### PR TITLE
Add side effects to package.json

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -10,6 +10,7 @@
   },
   "typings": "types/ssr-window.d.ts",
   "type": "module",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nolimits4web/ssr-window.git"


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code. Good with esm, modules, named imports.